### PR TITLE
app-containers/nvidia-container-toolkit, libnvidia-container/libnvidia-container: fix BDEPEND

### DIFF
--- a/app-containers/nvidia-container-toolkit/nvidia-container-toolkit-1.12.1.ebuild
+++ b/app-containers/nvidia-container-toolkit/nvidia-container-toolkit-1.12.1.ebuild
@@ -41,7 +41,7 @@ DEPEND="${RDEPEND}"
 
 BDEPEND="
 	app-arch/unzip
-	sys-devel/make
+	dev-build/make
 "
 
 src_compile() {

--- a/sys-libs/libnvidia-container/libnvidia-container-1.12.1.ebuild
+++ b/sys-libs/libnvidia-container/libnvidia-container-1.12.1.ebuild
@@ -34,7 +34,7 @@ DEPEND="${RDEPEND}"
 BDEPEND="
 	net-libs/rpcsvc-proto
 	sys-apps/lsb-release
-	sys-devel/bmake
+	dev-build/bmake
 	virtual/pkgconfig
 "
 


### PR DESCRIPTION
Some packages have been moved from sys-devel to dev-build recently.

There could be more instances of this. I just committed and pushed changes of packages that I actually built myself.